### PR TITLE
feat(i18n): better 404 handling for missing translations

### DIFF
--- a/components/Errors/ErrorI18N.vue
+++ b/components/Errors/ErrorI18N.vue
@@ -1,0 +1,56 @@
+<template>
+  <div class="Vlt-grid">
+    <div class="Vlt-col Blog-error">
+      <h1>Ooops, we've not translated that post yet!</h1>
+      <p>
+        You've boldly gone where no one has <strike>gone</strike> translated
+        before. <br />
+        The page you requested could not be found.
+      </p>
+      <h2>Alternative Translations</h2>
+      <ol class="Vlt-list Vlt-list--simple">
+        <li v-for="(translation, index) in translations" :key="index">
+          <NLink
+            :to="localePath(translation.route, translation.locale)"
+            class="Vlt-link"
+            >({{ localeName(translation.locale) }})
+            {{ translation.title }}</NLink
+          >
+        </li>
+      </ol>
+      <NLink to="/" no-prefetch class="Vlt-btn Vlt-btn--app Vlt-btn--secondary">
+        Home page
+      </NLink>
+    </div>
+
+    <div class="Vlt-col Blog-error">
+      <img
+        src="../../node_modules/@vonagevolta/volta2/demo/templates/assets/img/error-400.svg"
+        alt="An image showing that an error has occured"
+      />
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    translations: {
+      type: Array,
+      required: true,
+    },
+  },
+
+  methods: {
+    localeName(code) {
+      return this.$i18n.locales.find((i) => i.code === code).name
+    },
+  },
+}
+</script>
+
+<style scoped>
+.Vlt-error-page .Blog-error {
+  margin-top: 100px;
+}
+</style>

--- a/layouts/error.vue
+++ b/layouts/error.vue
@@ -1,7 +1,8 @@
 <template>
   <div class="Vlt-error-page">
     <div class="Vlt-container">
-      <Error404 v-if="error.statusCode === 404" />
+      <ErrorI18N v-if="errorType === 'i18n'" :translations="translations" />
+      <Error404 v-else-if="errorType === '404'" />
       <Error400 v-else />
     </div>
   </div>
@@ -9,13 +10,47 @@
 
 <script>
 export default {
-  layout: 'default',
   props: {
     error: {
       type: Object,
       required: true,
     },
-  }, // you can set a custom layout for the error page
+  },
+
+  data() {
+    return {
+      translations: [],
+    }
+  },
+
+  async fetch() {
+    if (this.$route.name) {
+      if (this.$route.name.startsWith('blog')) {
+        const { slug } = this.$route.params
+        this.translations = await this.$content('blog', { deep: true })
+          .where({
+            $and: [{ slug }, { published: { $ne: false } }],
+          })
+          .fetch()
+      }
+    }
+  },
+
+  computed: {
+    errorType() {
+      if (this.translations.length > 0) {
+        this.error.statusCode = 200
+
+        return 'i18n'
+      }
+
+      if (this.error.statusCode === 404) {
+        return '404'
+      }
+
+      return '400'
+    },
+  },
 }
 </script>
 

--- a/layouts/error.vue
+++ b/layouts/error.vue
@@ -39,8 +39,6 @@ export default {
   computed: {
     errorType() {
       if (this.translations.length > 0) {
-        this.error.statusCode = 200
-
         return 'i18n'
       }
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] You've followed the [contributing guidelines][contributing]
- [x] You've adheared the [code of conduct][coc]

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

new feature: missing translations for blog posts will now show alternative languages

* **What is the current behavior?** (You can also link to an open issue here)

returns 404

* **What is the new behavior (if this is a feature change)?**

checks for any posts using the same slug, change error code based on whether we find posts, return list of posts and different error page

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

no

* **Other information**:

before:
![image](https://user-images.githubusercontent.com/956290/98913078-d1f7db80-24be-11eb-8d26-02fd58d6a1a7.png)

after:
![image](https://user-images.githubusercontent.com/956290/98913101-da501680-24be-11eb-8fad-c95653b70b95.png)


[coc]: CODE_OF_CONDUCT.md "Code of Conduct"
[contributing]: CONTRIBUTING.md "Contributing"
