### PR TITLE
Remove duplicate sentence in spotlight submission copy

### DIFF
--- a/pages/spotlight/index.vue
+++ b/pages/spotlight/index.vue
@@ -148,7 +148,6 @@
           </ul>
           <p class="mb-2">
             The more details you provide, the better feedback we can give you.
-            The final draft should be around 2000 words
           </p>
           <p class="mb-2">The final draft should be around 2000 words</p>
 


### PR DESCRIPTION
"The final draft should be around 2000 words" appears twice in a row, removing one of them.

* **Please check if the PR fulfils these requirements**
- You've followed the [contributing guidelines][contributing]
- You've adhered to the [code of conduct][coc]

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

copy edit

* **What is the current behaviour?** (You can also link to an open issue here)

"The final draft should be around 2000 words" appears twice in a row

* **What is the new behaviour (if this is a feature change)?**

"The final draft should be around 2000 words" appears once

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

no
