### PR TITLE
APIDOC-148 added redirection route for HOME page

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -135,6 +135,12 @@
   force = true
 
 [[redirects]]
+  from = "/"
+  to = "https://developer.vonage.com/blog"
+  status = 301
+  force = true
+
+[[redirects]]
   from = "/blog/:year/:month/:day/:blog_path"
   to = "https://developer.vonage.com/blog/:year/:month/:day/:blog_path"
   status = 301


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Home page redirection


* **What is the current behavior?** (You can also link to an open issue here)
Home page is `learn.vonage.com`


* **What is the new behavior (if this is a feature change)?**
Home page is `developer.vonage.com`


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
YES
